### PR TITLE
Allow juxtaposition for concatenation

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,11 +91,13 @@ Ranges have no specific definition of what a range "is". It should be obvious wh
 
 #### Concatenation
 
-The concatenation operator is the comma `,`. It does not define what whitespace is allowed between terms; it is assumed that the reader knows what is and isn't allowed.
+Concatenation can be defined using the comma `,` operator between terms or by juxtaposition of terms.
+
+It does not define what whitespace is allowed between terms; it is assumed that the reader knows what is and isn't allowed.
 
 ```ebnf
 "A", "B", "C" (* probably "ABC" *)
-"fn", name, "()" (* probably "fn foo()" *)
+"fn" name "()" (* probably "fn foo()" *)
 ```
 
 #### Alternation

--- a/language/token.ts
+++ b/language/token.ts
@@ -5,6 +5,7 @@ export const enum Token {
   Ident,
   Comment,
   String,
+  Special,
 
   operatorStart,
   Semi,
@@ -13,7 +14,6 @@ export const enum Token {
   Except,
   Range,
   Concatenate,
-  Special,
   operatorEnd,
 
   LBrace,


### PR DESCRIPTION
Allow for omitting the concatenation operator `,` in expressions by treating the start of a new expression as an implicit concatenation. 

Closes #4.